### PR TITLE
增加api:@app.post("/ticket/availability")

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -2,24 +2,16 @@ from fastapi import FastAPI,Request
 from starlette.middleware.sessions import SessionMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
-from ProjectTools.Tools import Tools
-from Modules import RegisterModule,LoginModule,IndexModule,LogoutModule,ProfileModule,TicketModule
+from .ProjectTools.Tools import Tools
+from .Modules import RegisterModule,LoginModule,IndexModule,LogoutModule,ProfileModule,TicketModule
 
+import os
+from dotenv import load_dotenv
 app = FastAPI()
 KEY = "ticket_key"
 app.add_middleware(SessionMiddleware,secret_key=KEY)
 #mysql://root:DdAmmOtQGtxHmxhCiTZTxYmSgrnLlBSk@gondola.proxy.rlwy.net:51385/railway
-'''
-tools = Tools(
-                USER = "root",
-                PASSWORD = "DdAmmOtQGtxHmxhCiTZTxYmSgrnLlBSk",
-                HOST = "gondola.proxy.rlwy.net",
-                PORT = 51385,
-                DATABASE = "GJun"
-              )
-'''
-import os
-from dotenv import load_dotenv
+
 load_dotenv()
 tools = Tools(
                 USER = os.getenv("MYSQLUSER"),
@@ -28,7 +20,7 @@ tools = Tools(
                 PORT = int(os.getenv("MYSQLPORT")),
                 DATABASE = os.getenv("MYSQLPORT")
               )
-#'''
+
 @app.post("/auth/verify/init")
 async def ShowQRcode(request: Request):
     response = await RegisterModule.ShowQRcode(tools=tools,request=request)
@@ -60,11 +52,11 @@ async def User(request : Request):
     return JSONResponse(response)
 
 @app.post("/ticket")
-async def Ticket(request : Request):
+async def GetTicket(request : Request):
     response = await TicketModule.GetTicketData(tools=tools, request=request)
     return JSONResponse(response)
 
-@app.get("/ticket/availability")
+@app.post("/ticket/availability")
 async def GetTicketAvailability(request : Request):
     response = await TicketModule.CheckTicketPurchased(tools=tools, request=request)
     return JSONResponse(response)


### PR DESCRIPTION
網頁載入時就要使用，此api功能是取出該活動已經被選取的票券資料
本地端的做法是用get將首頁的title(活動名稱)傳到購票頁面
設置為全域變數之後，將此活動名稱給這個api
就會回傳已經選過的票券資料
前端再把這些資料做使用，將資料使用再"已經選過的位置做反灰"的動作
以此實現預防超選票的目的

購票的程序有修正，重點著重在更新資料庫的指令